### PR TITLE
Use strict-di

### DIFF
--- a/focusIf.js
+++ b/focusIf.js
@@ -2,7 +2,7 @@
     'use strict';
     angular
         .module('focus-if', [])
-        .directive('focusIf', focusIf);
+        .directive('focusIf', ["$timeout", focusIf]);
 
     function focusIf($timeout) {
         function link($scope, $element, $attrs) {


### PR DESCRIPTION
Annotate the directive to use strict dependency injection. Allows to use the directive in environments where strict-di is enforced
