### PR TITLE
add $inject declaration for di strict mode

### DIFF
--- a/focusIf.js
+++ b/focusIf.js
@@ -4,6 +4,8 @@
         .module('focus-if', [])
         .directive('focusIf', focusIf);
 
+    focusIf.$inject = ['$timeout'];
+
     function focusIf($timeout) {
         function link($scope, $element, $attrs) {
             var dom = $element[0];


### PR DESCRIPTION
### Yes, another di-strict mode/minification PR....

First of all, i already saw https://github.com/hiebj/ng-focus-if/pull/9 and https://github.com/hiebj/ng-focus-if/pull/13 but personally i prefer handling it via `$inject` property.
### I also read discussions in other PR's...
#### Why in my opinion this should be added?
- This is external library with intention for other people to use so it should be as dev friendly as possible.
- This will make directive strict di compliant
- This will save people time. Trying to find what vendor code is causing app crashes after minification isn't pleasant experience.

I personally like to use unminified versions of vendor files in dev environment (for better debugging) and then minify whole code at build process.
