### PR TITLE
add support for common js loaders

### DIFF
--- a/focusIf.js
+++ b/focusIf.js
@@ -25,4 +25,8 @@
             link: link
         };
     }
+
+    if (typeof module !== 'undefined' && module && module.exports) {
+        module.exports = 'focus-if';
+    }
 })();


### PR DESCRIPTION
It's common to export module name so it could be used as module dependency in common js require use case. 

**For example**:

``` js
var ngFocusIf = require('ng-focus-if');

var module = angular.module('my-module', [ngFocusIf]);
```
