### PR TITLE
Add angular to dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,5 +26,8 @@
     "bower_components",
     "test",
     "tests"
+  ],
+  "dependencies": [
+    "angular": "1.x"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "test",
     "tests"
   ],
-  "dependencies": [
+  "dependencies": {
     "angular": "1.x"
-  ]
+  }
 }


### PR DESCRIPTION
This fixes a load order issue when using automated build tools such as `bower-main-files`.
